### PR TITLE
Possible fix.. Not sure

### DIFF
--- a/src/cache/Aggregate.cpp
+++ b/src/cache/Aggregate.cpp
@@ -46,6 +46,7 @@ void Aggregate::mergeJSON(const Value& dump) {
   // Check length of values
   if(length == 0) {
     fprintf(stderr, "Empty 'values' array in dump!\n");
+    return;
   }
 
   // Check that we have doubles


### PR DESCRIPTION
If we see crashes with  `"Empty 'values' array in dump!"` we should apply and rollout this patch.

Unless we start to see crashes... maybe we don't want to touch this.
