### PR TITLE
Aggregator fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,41 @@
-Telemetry Dashboard
-===================
-Telemetry dashboard is an analysis job that aggregates telemetry histograms and
-simple measures, and offers an decent presentation. The default dashboard
-developed in this repository is hosted at
-[telemetry.mozilla.org](http://telemetry.mozilla.org). But the aggregated data
-is also available for consumption by third-party applications, so you don't need
-to do the aggregation on your own.
+Telemetry Aggregator
+====================
+Telemetry Aggregator is an analysis job that aggregates telemetry histograms and simple measures. Aggregates are functions of histograms and simple measures, and include such things as the sum, count, and logarithmic sum.
+
+These values are consumed by dashboards such as the one hosted at [telemetry.mozilla.org](http://telemetry.mozilla.org).
 
 Consuming Telemetry Aggregations
 --------------------------------
-Include into your code `http://telemetry.mozilla.org/v1/telemetry.js` feel free
-to use the other modules too.
-Don't go about reading the raw JSON files, they are not designed for human
-consumption!
+The aggregated data is available for third-party applications via the `telemetry.js` library - it is not necessary to run this analysis job yourself.
 
+For consuming the results of the aggregations, see the [telemetry.js documentation](https://telemetry.mozilla.org/docs.html#Telemetry).
 
-Hacking Telemetry Dashboard
----------------------------
-If you want to improve the user-interface for telemetry dashboard, clone this
-repository, setup a static server that hosts the `html/` folder on our localhost
-and start hacking. This is easy!
+Avoid using or referencing the JSON data directly, as these may be changed or removed without warning.
 
-If you want to add new aggregations, or improve upon existing aggregations,
-change the storage format, take a look at `Formats.mkd`. Talk to the guy who is
-maintaining telemetry dashboard.
+Hacking Telemetry Aggregator
+----------------------------
+To improve the user-interface for telemetry dashboard, see the README for the [Telemetry Dashboard repository](https://github.com/mozilla/telemetry-dashboard).
 
-Basic flow is as follows:
-  1. An `.egg` file is generated with `make egg`
-  2. Analysis tasks are created with telemetry-server
-  3. `DashboardProcessor` from `analysis.py` aggregated telemetry submissions,
-     this process is driven by telemetry-server.
-  4. `Aggregator` from `aggregator.py` collects results from analysis tasks, by:
-    1. Downloads existing data from s3
-    2. Fetch task finished messages from SQS
-    3. Download `result.txt` files in parallel
-    4. Updates results on disk
-    5. Publishes updated results in a new subfolder of `current/` on s3, every
-       once in a while.
-    6. Check points all aggregated data to a subfolder of `check-points/` on s3,
-       every once in a while.
-    7. Repeat
+To add new aggregations, improve upon existing aggregations, or change the storage format, take a look at `Formats.mkd`. Additionally, make sure to talk to the telemetry dashboard maintainer(s).
+
+Setting up the development environment:
+
+  1. Install Subversion and LibLZMA.
+    * On Debian-derived systems, simply run `apt-get install liblzma-dev subversion`.
+    * On Windows, install [XZ-Utils](http://tukaani.org/xz/) and a Subversion distribution for Windows.
+  2. Generate build files with CMake: in the project directory, run `cmake .`.
+  3. Build all the targets by invoking `make`. These create executables that are invoked by the Python scripts.
+  4. Set up the Python scripts using `python setup.py build`.
+
+Primary workflow:
+
+  1. Analysis tasks are created and run by [telemetry-server](https://github.com/mozilla/telemetry-server).
+  2. The `DashboardProcessor` class in `dashboard/analysis.py` aggregates telemetry submissions. This is used in and driven by telemetry-server.
+  3. The `Aggregator` class in `dashboard/aggregator.py` collects results from analysis tasks:
+    1. Downloads existing data from S3.
+    2. Fetches task finished messages from SQS.
+    3. Downloads `result.txt` files in parallel.
+    4. Updates results on disk.
+    5. Publishes updated results in a new subfolder of `current/` on S3, every once in a while.
+    6. Check points all aggregated data to a subfolder of `check-points/` on S3, every once in a while.
+    7. Repeat.

--- a/src/Aggregator.cpp
+++ b/src/Aggregator.cpp
@@ -60,6 +60,11 @@ int main(int argc, char *argv[]) {
   string line;
   line.reserve(4096);
   while (getline(*pi, line)) {
+    // Trim carriage returns in case we have Windows style line endings
+    if (!line.empty() && line[line.size() - 1] == '\r') {
+        line.erase(line.size() - 1);
+    }
+
     // Find first tab
     size_t tab = line.find('\t');
     if (tab == string::npos) {

--- a/src/cache/ResultSet.cpp
+++ b/src/cache/ResultSet.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <algorithm>
 #include <vector>
+#include <errno.h>
 
 using namespace std;
 using namespace rapidjson;
@@ -335,6 +336,10 @@ void ResultSet::aggregate(const std::string& prefix,
   measureFilename.reserve(2048);
 
   FILE* input = fopen(filename.data(), "r");
+  if (!input) {
+    fprintf(stderr, "Could not read (errno=%d) input file '%s'\n", errno, filename.data());
+  }
+
   {
     // Read file line by line
     CompressedFileReader reader(input);


### PR DESCRIPTION
- Include setup instructions in the README for compiling the aggregator, result merger, etc., and setting up the files.
  - The current instructions seem to apply to the old Make build setup rather than CMake.
  - `telemetry.js` now has its own documentation page with always up-to-date information about consuming aggregator results.
- Gracefully handle Windows-style line endings in the aggregator when reading input files.
  - At the moment, we simply crash.
- If any files in the input files are missing or otherwise cannot be read, print out an error message with the offending file before crashing.
